### PR TITLE
Integrate Loguru for improved logging

### DIFF
--- a/converttree.py
+++ b/converttree.py
@@ -1,6 +1,6 @@
 from thbud.model.budget import BudgetType, BudgetItem
 from thbud.textextract import DocumentText, get_entries, extract_tree_levels
-import logging
+from loguru import logger
 import json
 import pandas as pd
 import os
@@ -8,9 +8,6 @@ import time
 import re
 import fitz
 import subprocess
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 root_pdf_dir = 'toc/PDF'
 contents_filepath = 'toc/toc_output/toc.json'

--- a/convertxlsx.py
+++ b/convertxlsx.py
@@ -7,15 +7,12 @@ import re
 import concurrent.futures
 import traceback
 import pandas as pd
-import logging
+from loguru import logger
 
 
 OUTPUT_DIR = os.path.join('.', 'output-i', '2568_local-administration')
 xlsx_dir = './ฉบับร่างพระราชบัญญัติงบประมาณรายจ่าย (ร่าง พ.ร.บ.) (Excel)/'
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    filename='convertxlsx__.log',
-    level=logging.INFO)
+logger.add('convertxlsx__.log', level='INFO')
 
 
 class CannotFindStartPageError(Exception):
@@ -140,14 +137,14 @@ def process_file(file_path):
         for i in range(1, 12):
             if 'name_'+str(i) not in ministry_df.columns:
                 ministry_df['name_'+str(i)] = ''
-                print('name_'+str(i), 'not in columns')
+            logger.info(f'name_{i} not in columns')
         cols = extract_dataframe_columns(ministry_df)
         ministry_df = ministry_df[cols]
         ministry_df.to_csv(output_file_path, index=False)
-        logger.info('Saved CSV to ' + output_file_path)
+    logger.info(f'Saved CSV to {output_file_path}')
 
         """
-        print('Done', file_path)
+    logger.info(f'Done {file_path}')
 
         with open(output_file_path, 'w') as fp:
             json.dump(
@@ -159,12 +156,12 @@ def process_file(file_path):
         """
 
     except CannotFindStartPageError as e:
-        logger.error(str(e) + ' in', '"'+file_path+'"')
+        logger.error(f'{e} in "{file_path}"')
     except NoEntriesFoundError as e:
-        logger.error(str(e) + ' in', '"'+file_path+'"')
+        logger.error(f'{e} in "{file_path}"')
     except Exception as e:
         # print the error and traceback
-        logger.error(str(e) + ' in', '"'+file_path+'"')
+        logger.error(f'{e} in "{file_path}"')
         traceback.print_exc()
         return
 
@@ -183,19 +180,18 @@ def build_tree_for_ministry(ministry_name, file_paths):
     tree_list = []
     for file_path in file_paths:
         file_name = os.path.basename(file_path)
-        budget_unit_logger = logging.getLogger(re.sub(r'\s+', '_', file_name))
-        budget_unit_logger.info('Processing "{}"'.format(file_path))
+        logger.info(f'Processing "{file_path}"')
         try:
             tree = build_tree_from_xlsx(file_path)
             tree.name = os.path.basename(file_path)
             tree.budget_type = BudgetType.BUDGETARY_UNIT
             tree.parent = root
         except CannotFindStartPageError as e:
-            budget_unit_logger.error('{} in "{}"'.format(str(e), file_path))
+            logger.error(f'{e} in "{file_path}"')
         except NoEntriesFoundError as e:
-            budget_unit_logger.error('{} in "{}"'.format(str(e), file_path))
+            logger.error(f'{e} in "{file_path}"')
         except Exception as e:
-            budget_unit_logger.error('{} in "{}"'.format(str(e), file_path))
+            logger.error(f'{e} in "{file_path}"')
             traceback.print_exc()
             return
 
@@ -215,18 +211,18 @@ def build_tree_for_ministry(ministry_name, file_paths):
             indent=4
         )
     
-    logger.info('Saved JSON to ' + output_file_path)
+    logger.info(f'Saved JSON to {output_file_path}')
 
     ministry_df = pd.DataFrame(root.to_rows())
     for i in range(1, 12):
         if 'name_'+str(i) not in ministry_df.columns:
-            print('name_'+str(i), 'not in columns')
+            logger.info(f'name_{i} not in columns')
             ministry_df['name_'+str(i)] = ''
     cols = extract_dataframe_columns(ministry_df)
     ministry_df = ministry_df[cols]
     ministry_df.to_csv(csv_file_path, index=False)
 
-    logger.info('Saved CSV to ' + csv_file_path)
+    logger.info(f'Saved CSV to {csv_file_path}')
 
     return tree_list
 
@@ -244,10 +240,9 @@ def group_files_by_directory(file_paths):
 
 
 def main():
-    logger.setLevel(0)
     logger.info('*'*80)
-    logger.info('Start processing ' + xlsx_dir)
-    logger.info('Output to ' + OUTPUT_DIR)
+    logger.info(f'Start processing {xlsx_dir}')
+    logger.info(f'Output to {OUTPUT_DIR}')
     logger.info('*'*80)
     # process_file(
     #     'ฉบับร่างพระราชบัญญัติงบประมาณรายจ่าย (ร่าง พ.ร.บ.) (Excel)/เล่ม 5/กระทรวงคมนาคม/AO_08006 กรมทางหลวง 08.05.67.xlsx'
@@ -339,9 +334,7 @@ def main():
         #         file_paths, interested_bud_units
         #     )
 
-        logger.info('Processing {} files for {}'.format(
-            len(file_paths), ministry_name
-        ))
+        logger.info(f'Processing {len(file_paths)} files for {ministry_name}')
 
         # file_paths = [f for f in file_paths if '11012' in f]
 

--- a/merge_csv_files.py
+++ b/merge_csv_files.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import os
 import openpyxl
+from loguru import logger
 
 
 def list_file_in_directory(directory):
@@ -36,4 +37,4 @@ if __name__ == '__main__':
     directory = 'output/2568'
     output_file = 'output.xlsx'
     merge_csv_files(directory, output_file)
-    print('Done')
+    logger.info('Done')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ anytree
 pandas
 openpyxl
 opencv-python
+loguru

--- a/table_extract.py
+++ b/table_extract.py
@@ -1,5 +1,6 @@
 import fitz
 from thbud.tableparser import extract_tables
+from loguru import logger
 
 def extract_tables_test(filename: str, num_tables: int):
     doc = fitz.open(filename)
@@ -11,7 +12,7 @@ def extract_tables_test(filename: str, num_tables: int):
     page_height = page.rect.height
     # filter out the lines that are outside the page
 
-    print(len(rects))
+    logger.info(len(rects))
 
     def is_rect_inside_page(rect):
         return rect.x0 >= 0 and rect.x1 <= page_width and rect.y0 >= 0 and rect.y1 <= page_height
@@ -35,9 +36,9 @@ def extract_tables_test(filename: str, num_tables: int):
             )
     )
 
-    print('width', [r.width for r in rects])
+    logger.info(f"width {[r.width for r in rects]}")
     tables = extract_tables(rects)
-    print([[r.width*r.height for r in tab.rects] for tab in tables])
+    logger.info([[r.width*r.height for r in tab.rects] for tab in tables])
     assert len(tables) == num_tables
 
 # extract_tables_test('test/table-parser/pdf/pdf-0table.pdf', 0)

--- a/test/table-parser/test_extract.py
+++ b/test/table-parser/test_extract.py
@@ -1,5 +1,6 @@
 from thbud.tableparser import extract_tables, is_on_line, dfs
 import fitz
+from loguru import logger
 
 # is_on_line tests
 def test_is_on_line():
@@ -42,7 +43,7 @@ def extract_tables_test(filename: str, num_tables: int):
     # get the lines
     rects = [d['rect'] for d in page.get_drawings() if is_rect_inside_page(d['rect'], page.rect.width, page.rect.height)]
     tables = extract_tables(rects)
-    print([[r.width*r.height for r in tab.rects] for tab in tables])
+    logger.info([[r.width*r.height for r in tab.rects] for tab in tables])
     assert len(tables) == num_tables
 
 def test_extract_1_table():

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,27 @@
+import pytest
+from loguru import logger
+
+def simple_logging_function():
+    logger.info("This is a test log message.")
+
+def test_loguru_message_capture():
+    log_capture_list = []
+
+    # Define a sink function to append log messages to the list
+    def list_sink(message):
+        log_capture_list.append(message.record)
+
+    # Add the list-based sink
+    sink_id = logger.add(list_sink)
+
+    # Call the function that logs a message
+    simple_logging_function()
+
+    # Remove the sink to stop capturing
+    logger.remove(sink_id)
+
+    # Assert that the log message was captured
+    assert len(log_capture_list) == 1
+    log_record = log_capture_list[0]
+    assert log_record["level"].name == "INFO"
+    assert log_record["message"] == "This is a test log message."

--- a/thbud/textextract/pdf_to_tree.py
+++ b/thbud/textextract/pdf_to_tree.py
@@ -3,9 +3,7 @@ from typing import List, Tuple
 from ..textextract import DocumentText, PageText, LineText
 from ..model import BudgetItem, FiscalYearBudget
 import re
-import logging
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 """
 class LineWrapper:

--- a/thbud/textextract/text.py
+++ b/thbud/textextract/text.py
@@ -1,9 +1,7 @@
 import re
 from typing import List, Dict, Union
 from . import documenttext
-import logging
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 def mean(numbers: List[float]) -> float:

--- a/yellowbook.py
+++ b/yellowbook.py
@@ -1,11 +1,18 @@
 from thbud.textextract import DocumentText, LineText
 from thbud.textextract import LineItem, extract_tree_levels
 from typing import List
-import logging
+from loguru import logger
 import re
 import pandas as pd
-logger = logging.getLogger(__name__)
 
+logger.add(
+    "yellowbook.log",
+    rotation="10 MB",
+    retention="10 days",
+    level="INFO",
+    format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
+    enqueue=True,  # Process log messages asynchronously
+)
 
 class YBLineItem(LineItem):
     def __init__(self, itemtype: str, line_text: List[LineText]):
@@ -64,7 +71,7 @@ def get_entries(lines: List[LineText]):
             objective_or_kpi = False
 
         if (objective_or_kpi):
-            print('objective_or_kpi', line_text)
+            logger.info(f'objective_or_kpi {line_text}')
             continue
         entry.append(line)
 


### PR DESCRIPTION
This commit replaces the standard Python `logging` module with `loguru` across the codebase.

Key changes include:
- Added `loguru` to project dependencies.
- Replaced all instances of `logging` with `loguru.logger`.
- Configured `loguru` in `yellowbook.py` for file-based logging with rotation, retention, and a standardized format.
- Replaced `print()` statements used for logging/debugging with `logger` calls.
- Added a basic test case in `test/test_logging.py` to verify that log messages can be captured and asserted.

This change aims to provide a more robust, configurable, and user-friendly logging experience throughout the application.